### PR TITLE
Fix publish checkout

### DIFF
--- a/.github/workflows/release-publish-cd.yaml
+++ b/.github/workflows/release-publish-cd.yaml
@@ -16,6 +16,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: actions/setup-python@v2
         with:
           python-version: 3.12
@@ -23,7 +25,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip poetry
           poetry config virtualenvs.create false
-          poetry self install --sync
+          poetry install --sync
       - name: Build
         run: poetry build
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# Summary
Tag was not being fetched in `actions/checkout`, so the setting was changed to fetch it.