### PR TITLE
Fix publish checkout fetch tag

### DIFF
--- a/.github/workflows/release-publish-cd.yaml
+++ b/.github/workflows/release-publish-cd.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.12


### PR DESCRIPTION
# Summary
Workflow `fetch-tag` is not working.
`fetch-tag` change to `fetch-depth`.